### PR TITLE
attempt to fix pylint on circle

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,5 +4,5 @@ dependencies:
 
 test:
     override:
-        - pylint docker_iptables/docker_iptables.py
+        - pylint ./docker_iptables.py
         - python setup.py test


### PR DESCRIPTION
finally got pylint to work. requires ./ to work when run from the circle container
